### PR TITLE
Build 0.6.1 Ready for release

### DIFF
--- a/Chatterer/Chatterer.cs
+++ b/Chatterer/Chatterer.cs
@@ -348,7 +348,7 @@ namespace Chatterer
             controlDelay = 0;
 
         //Version
-        private string this_version = "0.6.0.86";
+        private string this_version = "0.6.1.86";
         private string main_window_title = "Chatterer ";
         private string latest_version = "";
         private bool recvd_latest_version = false;

--- a/Chatterer/Properties/AssemblyInfo.cs
+++ b/Chatterer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.0.86")]
+[assembly: AssemblyVersion("0.6.1.86")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Readme.txt
+++ b/Readme.txt
@@ -46,6 +46,13 @@ Usage :
 
 Changelog:
 
+v0.6.1: [31 Aug 2014]
+- fixed "Show advanced options" not showing on probes
+- fixed Skin mess up and made "none" the default,
+  (updated blacklist for unwanted Skin)
+  (blacklisted dupe skins as well)
+- fixed chatter menu showing in some case even if chatter button was disabled
+
 v0.6.0: [29 Aug 2014]
 - compiled for KSPv0.24.2
 - added stock KSP Application launcher button


### PR DESCRIPTION
Changelog:

v0.6.1: [31 Aug 2014]
- fixed "Show advanced options" not showing on probes
- fixed Skin mess up and made "none" the default,
  (updated blacklist for unwanted Skin)
  (blacklisted dupe skins as well)
- fixed chatter menu showing in some case even if chatter button was disabled
