### PR TITLE
Build 0.6.3 Ready for release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,16 @@
 Changelog:
 
+v0.6.3: [03 Sep 2014]
+- fixed and restored "Mute" function
+- added KSP application launcher button behaviours :
+* green = transmit (TX)
+* blue = receive (RX)
+* white = SSTV / Beep (flashing)
+* grey = idle (online)
+* grey/red = muted
+* red = disabled (offline) (for later use with RT2)
+- code cleaning and optimizations
+
 v0.6.2: [01 Sep 2014]
 - fixed "use Blizzy78' toolbar only" setting not loading
 - Added/tweaked GitHub and .version files for KSP-AVC "Add-on Version Checker" plugin support

--- a/Chatterer/Chatterer.cs
+++ b/Chatterer/Chatterer.cs
@@ -352,7 +352,7 @@ namespace Chatterer
             controlDelay = 0;
 
         //Version
-        private string this_version = "0.6.2.86";
+        private string this_version = "0.6.3.86";
         private string main_window_title = "Chatterer ";
         //private string latest_version = "";
         //private bool recvd_latest_version = false;

--- a/Chatterer/Properties/AssemblyInfo.cs
+++ b/Chatterer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.2.86")]
+[assembly: AssemblyVersion("0.6.3.86")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
v0.6.3: [03 Sep 2014]
- fixed and restored "Mute" function
- added KSP application launcher button behaviours :
- green = transmit (TX)
- blue = receive (RX)
- white = SSTV / Beep (flashing)
- grey = idle (online)
- grey/red = muted
- red = disabled (offline) (for later use with RT2)
- code cleaning and optimizations
