### PR TITLE
Build 0.6.4 Ready for release

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,5 +1,10 @@
 Changelog:
 
+v0.6.4: [04 Sep 2014]
+- fixed Airlock sound playing when switching vessel to/from EVAed Kerbal
+- removed warning msg in log about "soundscape" folder missing if not
+installed (was a safe warning anyway)
+
 v0.6.3: [03 Sep 2014]
 - fixed and restored "Mute" function
 - added KSP application launcher button behaviours :

--- a/Chatterer/Chatterer.cs
+++ b/Chatterer/Chatterer.cs
@@ -24,9 +24,8 @@
 
 /* DO ME
  * 
- * 1 - FIX EVA detection (avoid switching vessel to trigger Airlock sound)
- * 2 - Separate the code in different .cs files accordingly to their function
- * 
+ * 1 - Separate the code in different .cs files accordingly to their function
+ * 2 - Add RemoteTech 2 support
  * 
  * //
  * 
@@ -349,7 +348,7 @@ namespace Chatterer
             controlDelay = 0;
 
         //Version
-        private string this_version = "0.6.3.86";
+        private string this_version = "0.6.4.86";
         private string main_window_title = "Chatterer ";
         
         //Clipboards

--- a/Chatterer/Properties/AssemblyInfo.cs
+++ b/Chatterer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.6.3.86")]
+[assembly: AssemblyVersion("0.6.4.86")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
v0.6.4: [04 Sep 2014]
- fixed Airlock sound playing when switching vessel to/from EVAed Kerbal
- removed warning msg in log about "soundscape" folder missing if not
  installed (was a safe warning anyway)
