### PR TITLE
Add public query methods and insta-chatter method

### DIFF
--- a/Chatterer/Chatterer.cs
+++ b/Chatterer/Chatterer.cs
@@ -4000,5 +4000,56 @@ namespace Chatterer
                 if (gui_running) stop_GUI();
             }
         }
+
+        // Returns true when the pod is speaking to CapCom, or the pods is
+        // transmitting SSTV data.
+        public bool VesselIsTransmitting()
+        {
+            if (sstv.isPlaying)
+            {
+                return true;
+            }
+            else
+            {
+                bool podInitiatedExchange = (initial_chatter_source == 1);
+                if (exchange_playing)
+                {
+                    return (podInitiatedExchange) ? initial_chatter.isPlaying : response_chatter.isPlaying;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Returns true when CapCom is speaking to the capsule.
+        public bool VesselIsReceiving()
+        {
+            bool capcomInitiatedExchange = (initial_chatter_source == 0);
+            if (exchange_playing)
+            {
+                return (capcomInitiatedExchange) ? initial_chatter.isPlaying : response_chatter.isPlaying;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        // Initiate insta-chatter as if the player pressed the insta-chatter
+        // button.  Treat it as always pod-initiated. like a crewmember
+        // decided to talk to mission control.
+        public void InitiateChatter()
+        {
+            if (insta_chatter_key_just_changed == false && exchange_playing == false && sstv.isPlaying == false)
+            {
+                //no chatter or sstv playing, play insta-chatter
+                if (debugging) Debug.Log("[CHATR] beginning exchange,insta-chatter");
+
+                pod_begins_exchange = true;
+                begin_exchange(0);
+            }
+        }
     }
 }

--- a/Chatterer/Chatterer.cs
+++ b/Chatterer/Chatterer.cs
@@ -4011,9 +4011,9 @@ namespace Chatterer
             }
             else
             {
-                bool podInitiatedExchange = (initial_chatter_source == 1);
                 if (exchange_playing)
                 {
+                    bool podInitiatedExchange = (initial_chatter_source == 1);
                     return (podInitiatedExchange) ? initial_chatter.isPlaying : response_chatter.isPlaying;
                 }
                 else
@@ -4026,9 +4026,9 @@ namespace Chatterer
         // Returns true when CapCom is speaking to the capsule.
         public bool VesselIsReceiving()
         {
-            bool capcomInitiatedExchange = (initial_chatter_source == 0);
             if (exchange_playing)
             {
+                bool capcomInitiatedExchange = (initial_chatter_source == 0);
                 return (capcomInitiatedExchange) ? initial_chatter.isPlaying : response_chatter.isPlaying;
             }
             else


### PR DESCRIPTION
Nothing fancy - it allows another mod to query if there is communication taking place, and it allows another mod to trigger insta-chatter.  I've tested it with a RasterPropMonitor dev build in KSP 1.1, and I see the results I expect.