### PR TITLE
Devbuild

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,8 @@
 Changelog:
+v0.9.97 [15 Sep 2019]
+- Recompiled for KSP v1.7.3
+- fixes a possible crash when using Scatterer and Chatterer together
+
 v0.9.96 [18 Oct 2018]
 - Recompiled for KSP v1.5.0.2332
 

--- a/Chatterer/Properties/AssemblyInfo.cs
+++ b/Chatterer/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.96.2332")]
+[assembly: AssemblyVersion("0.9.97.0000")]
 // [assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Changelog:
v0.9.97 [15 Sep 2019]
- Recompiled for KSP v1.7.3
- fixes a possible crash when using Scatterer and Chatterer together